### PR TITLE
Allow specifying host fingerprint for more security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 RUN apk add --no-cache openssh bash
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 D3rHase
+Copyright (c) 2022 D3rHase, Lingepumpe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Action to run a command on a remote server via ssh
 ## Usage
 
 ```yaml
-uses: Lingepumpe/ssh-command-action@{version}
+uses: D3rHase/ssh-command-action@{version}
 with:
-  ssh_host: ${{secrets.SSH_HOST}} # Remote server address / ip - Required: true
-  ssh_port: ${{secrets.SSH_PORT}} # Remote server port -  Default: 22 - Required: false
-  ssh_user: ${{secrets.SSH_USER}} # Remote server user - Required: true
-  ssh_private_key: ${{secrets.SSH_PRIVATE_KEY}} # Private ssh key registered on the remote server - Required: true
-  ssh_host_fingerprint: ${{secrets.SSH_HOST_FINGERPRINT}} # Public ssh key fingerprint, viewable via ssh-keyscan -H $HOST -p $PORT - Required: false
-  command: "echo 'Success'" # Command to be executed - Default: echo 'hello world' - Required: false
+  host: ${{secrets.HOST}} # Remote server address / ip - required
+  port: ${{secrets.PORT}} # Remote server port -  Default: 22 - optional
+  user: ${{secrets.USER}} # Remote server user - required
+  private_key: ${{secrets.PRIVATE_KEY}} # Private ssh key registered on the remote server - required
+  host_fingerprint: ${{secrets.HOST_FINGERPRINT}} # Public ssh key fingerprint, viewable via ssh-keyscan -H $HOST -p $PORT - optional
+  command: "echo 'hello world'" # Command to be executed - Default: echo 'hello world' - optional
 ```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # ssh-command-action
+
 Action to run a command on a remote server via ssh
 
 ## Usage
+
 ```yaml
-uses: D3rHase/ssh-command-action@{version}
+uses: Lingepumpe/ssh-command-action@{version}
 with:
-  HOST: ${{secrets.HOST}}                             # Remote server address / ip - Required: true
-  PORT: ${{secrets.PORT}}                             # Remote server port -  Default: 22 - Required: false
-  USER: ${{secrets.USER}}                             # Remote server user - Required: true
-  PRIVATE_SSH_KEY: ${{secrets.PRIVATE_SSH_KEY}}       # Private ssh key registered on the remote server - Required: true
-  COMMAND: ${{secrets.COMMAND}}                       # Command to be executed - Default: echo Hello world! - Required: false
+  ssh_host: ${{secrets.SSH_HOST}} # Remote server address / ip - Required: true
+  ssh_port: ${{secrets.SSH_PORT}} # Remote server port -  Default: 22 - Required: false
+  ssh_user: ${{secrets.SSH_USER}} # Remote server user - Required: true
+  ssh_private_key: ${{secrets.SSH_PRIVATE_KEY}} # Private ssh key registered on the remote server - Required: true
+  ssh_host_fingerprint: ${{secrets.SSH_HOST_FINGERPRINT}} # Public ssh key fingerprint, viewable via ssh-keyscan -H $HOST -p $PORT - Required: false
+  command: "echo 'Success'" # Command to be executed - Default: echo 'hello world' - Required: false
 ```

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ with:
   user: ${{secrets.USER}} # Remote server user - required
   private_key: ${{secrets.PRIVATE_KEY}} # Private ssh key registered on the remote server - required
   host_fingerprint: ${{secrets.HOST_FINGERPRINT}} # Public ssh key fingerprint, viewable via ssh-keyscan -H $HOST -p $PORT - optional
-  command: "echo 'hello world'" # Command to be executed - Default: echo 'hello world' - optional
+  command: echo 'hello world' # Command to be executed - Default: echo 'hello world' - optional
 ```

--- a/action.yml
+++ b/action.yml
@@ -2,20 +2,20 @@ name: "SSH Command"
 description: "Run a command on a remote server via ssh"
 
 inputs:
-  ssh_host:
+  host:
     description: "hostname / IP of the server"
     required: true
-  ssh_port:
+  port:
     description: "ssh port of the server"
     required: false
     default: "22"
-  ssh_user:
+  user:
     description: "user of the server"
     required: true
-  ssh_private_key:
+  private_key:
     description: "private ssh key registered on the server"
     required: true
-  ssh_host_fingerprint:
+  host_fingerprint:
     description: "Fingerprint of the server, preventing man-in-the-middle attacks"
     required: false
   command:
@@ -27,11 +27,11 @@ runs:
   using: "docker"
   image: "Dockerfile"
   env:
-    HOST: ${{ inputs.ssh_host }}
-    PORT: ${{ inputs.ssh_port }}
-    USER: ${{ inputs.ssh_user }}
-    PRIVATE_KEY: ${{ inputs.ssh_private_key }}
-    HOST_FINGERPRINT: ${{ inputs.ssh_host_fingerprint }}
+    HOST: ${{ inputs.host }}
+    PORT: ${{ inputs.port }}
+    USER: ${{ inputs.user }}
+    PRIVATE_KEY: ${{ inputs.private_key }}
+    HOST_FINGERPRINT: ${{ inputs.host_fingerprint }}
     COMMAND: ${{ inputs.command }}
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -1,36 +1,39 @@
-# action.yml
-name: 'SSH Command'
-description: 'Run a command on a remote server via ssh'
+name: "SSH Command"
+description: "Run a command on a remote server via ssh"
 
 inputs:
-  HOST:
-    description: 'hostname / IP of the server'
+  ssh_host:
+    description: "hostname / IP of the server"
     required: true
-  PORT:
-    description: 'ssh port of the server'
+  ssh_port:
+    description: "ssh port of the server"
     required: false
-    default: 22
-  USER:
-    description: 'user of the server'
+    default: "22"
+  ssh_user:
+    description: "user of the server"
     required: true
-  PRIVATE_SSH_KEY:
-    description: 'private ssh key registered on the server'
+  ssh_private_key:
+    description: "private ssh key registered on the server"
     required: true
-  COMMAND:
-    description: 'command to be executed'
+  ssh_host_fingerprint:
+    description: "Fingerprint of the server, preventing man-in-the-middle attacks"
     required: false
-    default: 'echo Hello World!'
+  command:
+    description: "command to be executed"
+    required: false
+    default: "echo 'Hello world'"
 
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
-  args:
-    - ${{ inputs.HOST }}
-    - ${{ inputs.PORT }}
-    - ${{ inputs.USER }}
-    - ${{ inputs.PRIVATE_SSH_KEY }}
-    - ${{ inputs.COMMAND }}
+  using: "docker"
+  image: "Dockerfile"
+  env:
+    HOST: ${{ inputs.ssh_host }}
+    PORT: ${{ inputs.ssh_port }}
+    USER: ${{ inputs.ssh_user }}
+    PRIVATE_KEY: ${{ inputs.ssh_private_key }}
+    HOST_FINGERPRINT: ${{ inputs.ssh_host_fingerprint }}
+    COMMAND: ${{ inputs.command }}
 
 branding:
-  icon: 'terminal'
-  color: 'yellow'
+  icon: "terminal"
+  color: "yellow"


### PR DESCRIPTION
Instead of running 

`ssh-keyscan -H -p ${PORT} ${HOST} > /root/.ssh/known_hosts`

On every execution of the action, allow the user to specify the host fingerprint in a parameter. This prevents man-in-the-middle attacks. Still supports the old behavior when host_fingerprint is not set, but warns in on stdout.